### PR TITLE
Fix the .dockerignore tab name and the hotspot pom.xml is referencing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -109,6 +109,7 @@ pom.xml
 ----
 include::finish/pom.xml[tags=**]
 ----
+
 // =================================================================================================
 // Creating the Dockerfile
 // =================================================================================================
@@ -162,14 +163,19 @@ as the Dockerfile to its build context, making them available for use in instruc
 To make image building faster, add all files and directories that aren't necessary for building your
 image to a `.dockerignore` file. This excludes them from the build context.
 
-A [hotspot file=1]`.dockerignore` file is available to you in the `start` directory. This file includes the [hotspot=2 file=0]`src`
-directory, the [hotspot=1 file=1]`pom.xml` file, and some system files. Feel free to add anything else that you want to exclude.
+A [hotspot file=0]`.dockerignore` file is available to you in the `start` directory. This file includes the [hotspot=2 file=0]`src`
+directory, the [hotspot file=1]`pom.xml` file, and some system files. Feel free to add anything else that you want to exclude.
 
-
-.dockerignore
+`.dockerignore`
 [source, text, linenums, role="code_column"]
 ----
 include::finish/.dockerignore[tags=**]
+----
+
+pom.xml
+[source, xml, linenums, role="code_column"]
+----
+include::finish/pom.xml[tags=**]
 ----
 // =================================================================================================
 // Building the image


### PR DESCRIPTION
Fix the .dockerignore tab name and also one of the hotspots needed pom.xml. Since the file name has a period in it we need to escape it.