### PR TITLE
removing copyright and updating instructions LMP version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -212,7 +212,7 @@ With your container running, make the following update to the source code:
 
 // File 0 
 PropertiesResource.java
-[source, java, linenums, role='code_column hide_tags=comment']
+[source, java, linenums, role='code_column hide_tags=comment,copyright']
 ----
 include::finish/src/main/java/io/openliberty/guides/rest/PropertiesResource.java[]
 ----
@@ -259,7 +259,7 @@ endif::[]
 
 // File 0
 EndpointIT.java
-[source, java, linenums, role='code_column hide_tags=comment']
+[source, java, linenums, role='code_column hide_tags=comment,copyright']
 ----
 include::finish/src/test/java/it/io/openliberty/guides/rest/EndpointIT.java[]
 ----
@@ -299,7 +299,7 @@ Another useful feature of dev mode with a container is the ability to pass addit
 ----
 <groupId>io.openliberty.tools</groupId>
 <artifactId>liberty-maven-plugin</artifactId>
-<version>3.3.4</version>
+<version>3.7.1</version>
 <configuration>
     <dockerRunOpts>-e ENV_VAR=exampleValue</dockerRunOpts>
 </configuration>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/891

### Review changes
- [x]  pom.xml
  - java 11
  - jakarta is 10, microfile-profile is 6.0, and dependencies
  - LMP 3.7.1
- [x] server.xml
  - features version
- [x] index.html
  - license and features version
- [x] java files
  - EPL 2.0
- [x] License file
   - EPL 2.0

### End-to-end test
- [x] update lgdev with `version-update-mp6` branch
- [x] do end-to-end test and review content carefully
  - clone the `version-update-mp6` branch
  - if index.html has changes, make sure the links work

### Cloud hosted test
- [x] generate the cloud hosted dev lab
- [x] do end-to-end test and review content
  - clone the `version-update-mp6` branch
